### PR TITLE
Use relative URLs for images to fix HTTPS

### DIFF
--- a/app/code/community/Bubble/RequireLogin/etc/system.xml
+++ b/app/code/community/Bubble/RequireLogin/etc/system.xml
@@ -2,7 +2,7 @@
 <config>
     <tabs>
         <bubble translate="label">
-            <label><![CDATA[<div><img src="http://i.imgur.com/nkD1M9R.png" alt="BubbleCode" title="BubbleCode" width="108" height="23" style="display:block;" /></div>]]></label>
+            <label><![CDATA[<div><img src="//i.imgur.com/nkD1M9R.png" alt="BubbleCode" title="BubbleCode" width="108" height="23" style="display:block;" /></div>]]></label>
             <sort_order>1000</sort_order>
         </bubble>
     </tabs>

--- a/app/design/adminhtml/base/default/template/bubble/requirelogin/system/config/fieldset/hint.phtml
+++ b/app/design/adminhtml/base/default/template/bubble/requirelogin/system/config/fieldset/hint.phtml
@@ -4,9 +4,9 @@
  */
 ?>
 <div class="box">
-    <div style="background:url('http://i.imgur.com/NtYmWIh.png') no-repeat left center;padding-left:55px;min-height:42px;">
+    <div style="background:url('//i.imgur.com/NtYmWIh.png') no-repeat left center;padding-left:55px;min-height:42px;">
         <a href="https://github.com/jreinke/magento-require-login" target="_blank" style="float:right;">
-            <img src="http://i.imgur.com/QVKwCFx.png" alt="Fork me on GitHub" title="Fork me on GitHub" />
+            <img src="//i.imgur.com/QVKwCFx.png" alt="Fork me on GitHub" title="Fork me on GitHub" />
         </a>
         <h4><?php echo $this->helper('bubble_requirelogin')->__('Bubble RequireLogin is a module that can force user authentication in frontend.'); ?></h4>
         <p style="margin-bottom:0;"><?php echo $this->helper('bubble_requirelogin')->__('Full overview available'); ?> <a href="<?php echo $this->escapeHtml($this->helper('bubble_requirelogin')->__('http://www.bubblecode.net/en/2012/05/15/a-magento-module-to-require-login-on-your-store/')); ?>" target="_blank"><?php echo $this->helper('bubble_requirelogin')->__('here'); ?></a>.</p>


### PR DESCRIPTION
Currently get SSL errors in the Magento admin if _"Use Secure URLs in Admin"_ is set to Yes.
