### PR TITLE
Fixing issue where user is not redirected to their original URL after login

### DIFF
--- a/app/code/community/Bubble/RequireLogin/Model/Customer/Observer.php
+++ b/app/code/community/Bubble/RequireLogin/Model/Customer/Observer.php
@@ -18,7 +18,13 @@ class Bubble_RequireLogin_Model_Customer_Observer
             $requestString = $controllerAction->getRequest()->getRequestString();
 
             if (!preg_match($helper->getWhitelist(), $requestString)) {
-                $session->setBeforeAuthUrl(Mage::helper('core/url')->getCurrentUrl());
+                // If logging in from the homepage, the only way back is using the Magento internal homepage path. Magento ignores a setBeforeAuthUrl with the site base URL
+                if (Mage::helper('core/url')->getCurrentUrl() == Mage::getBaseUrl()) {
+                    $session->setBeforeAuthUrl(Mage::getUrl('*/*/*', array('_current' => true)));
+                } else {
+                    $session->setBeforeAuthUrl(Mage::helper('core/url')->getCurrentUrl());
+                }
+
                 $controllerAction->getResponse()->setRedirect(Mage::getUrl('customer/account/login'));
                 $controllerAction->getResponse()->sendResponse();
                 exit;

--- a/app/code/community/Bubble/RequireLogin/Model/Customer/Observer.php
+++ b/app/code/community/Bubble/RequireLogin/Model/Customer/Observer.php
@@ -18,7 +18,7 @@ class Bubble_RequireLogin_Model_Customer_Observer
             $requestString = $controllerAction->getRequest()->getRequestString();
 
             if (!preg_match($helper->getWhitelist(), $requestString)) {
-                $session->setBeforeAuthUrl($requestString);
+                $session->setBeforeAuthUrl(Mage::helper('core/url')->getCurrentUrl());
                 $controllerAction->getResponse()->setRedirect(Mage::getUrl('customer/account/login'));
                 $controllerAction->getResponse()->sendResponse();
                 exit;


### PR DESCRIPTION
This fixes a couple of things when `Configuration > System > Customers > Customer Configuration > "Redirect Customer to Account Dashboard after Logging in"` is set to "No".

Upon logging in, user is always redirected to Account Dashboard, even with that setting applied. They should instead be redirected to their original destination (which might be the homepage, or anywhere else).

The reason is that `$session->setBeforeAuthUrl()` expects a full URL, not just `$requestString`.

I've had to make an additional provision for when the user has been redirected to log in from the homepage in particular. This is because passing the site _base URL_ (e.g. "http://www.example.com") to `$session->setBeforeAuthUrl()` gets ignored by Magento's account controller (at least in Magento 1.9, not sure about older versions).

To ensure that we redirect users back to the homepage, if that's where they started, I've had to force the Magento internal path for the homepage into `$session->setBeforeAuthUrl()`.
